### PR TITLE
Added support to load stylesheets with query string in theme config

### DIFF
--- a/src/AssetContainer.php
+++ b/src/AssetContainer.php
@@ -192,7 +192,7 @@ class AssetContainer {
         }
         else
         {
-            $type = (pathinfo($source, PATHINFO_EXTENSION) == 'css') ? 'style' : 'script';
+            $type = (pathinfo(parse_url($source, PHP_URL_PATH), PATHINFO_EXTENSION) == 'css') ? 'style' : 'script';
 
             // Remove unnecessary slashes from internal path.
             if ( ! preg_match('|^//|', $source))


### PR DESCRIPTION
Sometime we might need to bypass cloudflare cache or browser cache by adding query strings in stylesheets to immediately take effect changes.
```
$asset->themePath()->add([
    ['css', 'css/style.css?v=1553931830'],
    ['js', 'js/script.js?v=1553931830']
]);
```