### PR TITLE
Updated for Laravel 7.4

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -413,7 +413,7 @@ class Theme implements ThemeContract
         // Evaluate theme config.
         $this->themeConfig = $this->evaluateConfig($this->themeConfig);
 
-        return is_null($key) ? $this->themeConfig : array_get($this->themeConfig, $key);
+        return is_null($key) ? $this->themeConfig : Arr::get($this->themeConfig, $key);
     }
 
     /**

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -413,7 +413,7 @@ class Theme implements ThemeContract
         // Evaluate theme config.
         $this->themeConfig = $this->evaluateConfig($this->themeConfig);
 
-        return is_null($key) ? $this->themeConfig : Arr::get($this->themeConfig, $key);
+        return is_null($key) ? $this->themeConfig : \Arr::get($this->themeConfig, $key);
     }
 
     /**


### PR DESCRIPTION
Removes deprecated array_get function on line 416. 

Replaced with:
`return is_null($key) ? $this->themeConfig : \Arr::get($this->themeConfig, $key);`