### PR TITLE
Adding ThemeRepository

### DIFF
--- a/src/Contracts/ThemeRepository.php
+++ b/src/Contracts/ThemeRepository.php
@@ -1,0 +1,15 @@
+<?php 
+
+namespace Facuz\Theme\Contracts;
+
+interface ThemeRepository 
+{
+    /**
+     * Register the theme to repository
+     *
+     * @param string $themeName
+     * @param array $options
+     * @return void
+     */
+    public function register(string $themeName, array $options);
+}

--- a/src/ThemeRepository.php
+++ b/src/ThemeRepository.php
@@ -1,0 +1,134 @@
+<?php 
+
+namespace Facuz\Theme;
+
+use Facuz\Theme\Contracts\ThemeRepository as ThemeRepositoryContract;
+use Illuminate\Filesystem\Filesystem;
+
+
+class ThemeRepository implements ThemeRepositoryContract
+{
+
+    /**
+     * Main variables for storing the registered theme information
+     *
+     * @var array
+     */
+    public $repository = [];
+
+
+
+    /**
+     * Register the theme to repository
+     *
+     * @param string $themeName
+     * @param array $options
+     * @return void
+     */
+    public function register(string $themeName, array $options)
+    {
+        $this->repository[$themeName] = $options;
+    }
+
+
+
+    /**
+     * Retrieving values using dotted notation
+     *
+     * @param string $key
+     * @param any $default
+     * @return void
+     */
+    public function get(string $key, $default = null) 
+    {
+        return data_get($this->repository, $key, $default);
+    }
+
+
+
+    /**
+     * Check if theme exists in repository
+     *
+     * @param string $key
+     * @param any $default
+     * @return void
+     */
+    public function has($themeName) 
+    {
+        return isset($this->repository[$themeName]) && !empty($this->repository[$themeName]);
+    }
+
+
+
+    /**
+     * Retrieving repository as collection
+     *
+     * @return void
+     */
+    public function collect()
+    {
+        return collect($this->repository);
+    }
+
+
+    /**
+     * Get all registered theme
+     *
+     * @return void
+     */
+    public function all()
+    {
+        return $this->repository;
+    }
+
+
+    /**
+     * Get the theme names
+     *
+     * @return void
+     */
+    public function getThemeNames()
+    {
+        return array_keys($this->repository);
+    }
+
+
+    /**
+     * Scan directory for themes
+     *
+     * @param string $themeDir
+     * @return void
+     */
+    public function scan(string $themeDir = '')
+    {
+        $files = new Filesystem();
+        if (!empty($themeDir) && $files->isDirectory(base_path($themeDir))) {
+            $scannedThemes = $files->directories(base_path($themeDir));
+            foreach ($scannedThemes as $theme) {
+                $themeName = basename($theme);
+                $jsonFile = "$theme/theme.json";
+
+                if (file_exists($jsonFile)) {
+                    $info = (array) json_decode(file_get_contents($jsonFile));
+                    $info['path'] = "$themeDir/$themeName";
+
+                    $this->register($themeName, $info);
+                }
+            }
+        }
+    }
+
+
+
+    /**
+     * Generate the full path for specified theme
+     *
+     * @param string $theme
+     * @param string $path
+     * @return string
+     */
+    public function path(string $theme = '', string $path = ''): string
+    {
+        return base_path($this->get("$theme.path") . $path);
+    }
+}

--- a/src/ThemeServiceProvider.php
+++ b/src/ThemeServiceProvider.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 
+
 class ThemeServiceProvider extends ServiceProvider {
 
 	/**
@@ -66,6 +67,7 @@ class ThemeServiceProvider extends ServiceProvider {
 		$app = $this->app;
 
 		// Register providers:
+        $this->registerThemeRepository();
 		$this->registerAsset();
 		$this->registerTheme();
 		$this->registerWidget();
@@ -235,6 +237,22 @@ class ThemeServiceProvider extends ServiceProvider {
 		$this->app->singleton('theme.list', function($app)
 		{
 			return new Commands\ThemeListCommand($app['config'], $app['files']);
+		});
+	}
+
+
+    /**
+	 * Register themes repository.
+	 *
+	 * @return void
+	 */
+	public function registerThemeRepository()
+	{
+		$this->app->singleton('themes', function($app)
+		{
+            $repository = new ThemeRepository();
+            $repository->scan(config('theme.themeDir', ''));
+			return $repository;
 		});
 	}
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,7 +8,8 @@ if (!function_exists('theme')){
 	 * @param  string  $layoutName
 	 * @return \Facuz\Theme\Theme
 	 */
-	function theme($themeName = null, $layoutName = null){
+	function theme($themeName = null, $layoutName = null) 
+    {
 		$theme = app('theme');
 
 		if ($themeName){
@@ -31,7 +32,8 @@ if (!function_exists('protectEmail')){
 	 * @param  string  $email
 	 * @return string
 	 */
-	function protectEmail($email) {
+	function protectEmail($email) 
+    {
 		$p = str_split(trim($email));
 		$new_mail = '';
 
@@ -50,9 +52,26 @@ if (!function_exists('meta_init')){
 	 *
 	 * @return string
 	 */
-	function meta_init() {
+	function meta_init() 
+    {
 		return '<meta charset="utf-8">'.
 		'<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">'.
 		'<meta name="viewport" content="width=device-width, initial-scale=1">';
 	}
+}
+
+
+
+if (!function_exists('theme_path')) {
+    /**
+     * Generate path to theme
+     *
+     * @param string $theme
+     * @param string $path
+     * @return string
+     */
+    function theme_path(string $theme = '', string $path = ''): string
+    {
+        return app('themes')->path($theme, $path);
+    }
 }


### PR DESCRIPTION
Adding ThemeRepository capability to allow other developer to create theme as a separated Laravel package and then register them via ThemeRepository.

At the custom theme ServiceProvider, one could register it to the LaravelTheme repository:

```
namespace MyPrefix\MyTheme;

use Illuminate\Support\ServiceProvider;


/**
 * Service class for registering the theme into the main Theme repository
 */
class ThemeServiceProvider extends ServiceProvider
{

    /**
     * Bootstrap the application services.
     */
    public function boot()
    {

        // Registering theme to theme repository
        // Inject the content of theme.json here directly to save file access time
        $relative_path = str_replace(base_path(), '', __DIR__);
        optional(app('themes'))
            ->register('my_slug', [
                'path' => rtrim(ltrim($relative_path, '/')) . '/theme',
                'slug' => 'my_slug',
                'name' => 'My Theme',
                'version' => '1.0',
                'description' => 'My Awesome Theme',
                'mode' => 'public'
            ]);


        // For Theme developer, publish the dist folder to laravel main public folder
        // Invoke this with command: php artisan vendor:publish --tag=theme_assets --force
        $this->publishes([
            __DIR__ . '/../dist' => public_path('theme/my_theme')
        ], 'theme_assets');
    }
}
```


Additional helper to get the right themepath

```
    /**
     * Generate path to theme
     *
     * @param string $theme
     * @param string $path
     * @return string
     */
    function theme_path(string $theme = '', string $path = ''): string
    {
        return app('themes')->path($theme, $path);
    }

```

It will return the correct vendor/path or the resources/path based on what path did the theme registered to.

